### PR TITLE
Added maxSuggestions option

### DIFF
--- a/jquery.sew.js
+++ b/jquery.sew.js
@@ -16,7 +16,8 @@
 			elementFactory: elementFactory,
 			values: [],
 			unique: false,
-			repeat: true
+			repeat: true,
+			maxSuggestions: 10
 		};
 
 	function Plugin(element, options) {
@@ -166,7 +167,8 @@
 							e.val.toLowerCase().indexOf(val.toLowerCase()) >= 0 ||
 							(e.meta || "").toLowerCase().indexOf(val.toLowerCase()) >= 0;
 		}, this));
-
+		
+		vals = vals.length > this.options.maxSuggestions ? vals.slice(0, this.options.maxSuggestions) : vals;
 		if(vals.length) {
 			this.renderElements(vals);
 			this.$itemList.show();


### PR DESCRIPTION
When the suggestion matches are too long, the incredibly long list with fixed positioning onscreen looks odd. This option helps restrict suggestions to a restricted number of items.
